### PR TITLE
build `tcl` / `tk` inside `magic-vlsi`

### DIFF
--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -30,8 +30,16 @@ class MagicVlsi < Formula
     ENV.deparallelize  # if your formula fails when building in parallel
 
     resource("tcl").stage do
+      tcl_tk_args = %W[
+        --prefix=#{prefix}
+        --includedir=#{include}/tcl-tk
+        --mandir=#{man}
+        --enable-threads
+        --enable-64bit
+      ]
+
       cd "unix" do
-        system "./configure", "--prefix=#{lib}/tcl-tk"
+        system "./configure", *tcl_tk_args
         system "make"
         system "make", "install"
       end
@@ -41,12 +49,12 @@ class MagicVlsi < Formula
       resource("tk").stage do
         cd "unix" do
           system "./configure",
-                 "--prefix=#{lib}/tcl-tk",
                  "--with-tcl=#{lib}/tcl-tk/lib",
-                 "--with-x",
                  "--enable-xss=no",
+                 "--with-x",
                  "--x-includes=/usr/X11/include",
-                 "--x-libraries=/usr/X11/lib"
+                 "--x-libraries=/usr/X11/lib",
+                 *tcl_tk_args
 
           inreplace "Makefile",
                     /^LIB_RUNTIME_DIR[^\n]*$/,

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -13,6 +13,7 @@ class MagicVlsi < Formula
   # So let's not use OpenGL
   # depends_on "mesa" => :build
   # depends_on "mesa-glu" => :build
+  depends_on "libx11"
   depends_on "python3"
 
   resource "tcl" do

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -31,7 +31,7 @@ class MagicVlsi < Formula
 
     resource("tcl").stage do
       tcl_tk_args = %W[
-        --prefix=#{prefix}
+        --prefix=#{prefix}/tcl-tk
         --includedir=#{include}/tcl-tk
         --mandir=#{man}
         --enable-threads
@@ -49,7 +49,7 @@ class MagicVlsi < Formula
       resource("tk").stage do
         cd "unix" do
           system "./configure",
-                 "--with-tcl=#{lib}/tcl-tk/lib",
+                 "--with-tcl=#{prefix}/tcl-tk/lib",
                  "--enable-xss=no",
                  "--with-x",
                  "--x-includes=/usr/X11/include",
@@ -68,8 +68,8 @@ class MagicVlsi < Formula
 
     system "./configure",
            "--prefix=#{prefix}",
-           "--with-tcl=#{lib}/tcl-tk/lib",
-           "--with-tk=#{lib}/tcl-tk/lib",
+           "--with-tcl=#{prefix}/tcl-tk/lib",
+           "--with-tk=#{prefix}/tcl-tk/lib",
            "--x-includes=/usr/X11/include",
            "--x-libraries=/usr/X11/lib",
            "--with-opengl=no", # disable OpenGL

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -12,6 +12,7 @@ class MagicVlsi < Formula
   # So let's not use OpenGL
   # depends_on "mesa" => :build
   # depends_on "mesa-glu" => :build
+  depends_on "python3"
 
   resource "tcl" do
     url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8.6.13-src.tar.gz"
@@ -63,7 +64,9 @@ class MagicVlsi < Formula
            "--x-includes=/usr/X11/include",
            "--x-libraries=/usr/X11/lib",
            "--with-opengl=no", # disable OpenGL
-           "--disable-silent-rules", *std_configure_args
+           "--disable-silent-rules",
+           "PYTHON3=#{Formula["python3"].bin}/python3",
+           *std_configure_args
     ENV["CFLAGS"] = "-Wno-error=implicit-function-declaration"
     system "make"
     system "make", "install"

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -65,9 +65,9 @@ class MagicVlsi < Formula
            "--x-libraries=/usr/X11/lib",
            "--with-opengl=no", # disable OpenGL
            "--disable-silent-rules",
+           "CFLAGS=-Wno-implicit-function-declaration",
            "PYTHON3=#{Formula["python3"].bin}/python3",
            *std_configure_args
-    ENV["CFLAGS"] = "-Wno-error=implicit-function-declaration"
     system "make"
     system "make", "install"
   end

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -59,6 +59,7 @@ class MagicVlsi < Formula
                  "--with-x",
                  "--x-includes=/opt/X11/include",
                  "--x-libraries=/opt/X11/lib",
+                 "CFLAGS=-I/opt/X11/include",
                  *tcl_tk_args
 
           inreplace "Makefile",

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -42,6 +42,7 @@ class MagicVlsi < Formula
                *tcl_tk_args
         system "make"
         system "make", "install"
+        system "make", "install-private-headers"
       end
 
       ENV.prepend_path "PATH", bin
@@ -62,6 +63,7 @@ class MagicVlsi < Formula
 
           system "make"
           system "make", "install"
+          system "make", "install-private-headers"
         end
       end
     end

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -6,14 +6,18 @@ class MagicVlsi < Formula
   sha256 "ef17c343c89ac54699f87f6c853ec7e4814f322734bd3b54a157a7d95cab905a"
   license "MIT"
 
-  # magic crashes on start with a BadMatch error:
-  ### X Error of failed request:  BadMatch (invalid parameter attributes)
-  ### Major opcode of failed request:  149 (GLX)
-  ### Minor opcode of failed request:  27 (X_GLXCreatePbuffer)
-  # So let's not use OpenGL
-  # depends_on "mesa" => :build
-  # depends_on "mesa-glu" => :build
+  depends_on :macos
+
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "libglu"
+  depends_on "libice"
   depends_on "libx11"
+  depends_on "libxext"
+  depends_on "libxi"
+  depends_on "libxmu"
+  depends_on "libxrender"
+  depends_on "mesa"
   depends_on "python3"
 
   resource "tcl" do

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -32,7 +32,6 @@ class MagicVlsi < Formula
     resource("tcl").stage do
       tcl_tk_args = %W[
         --prefix=#{prefix}/tcl-tk
-        --mandir=#{man}
         --enable-threads
         --enable-64bit
       ]

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -1,7 +1,8 @@
 class MagicVlsi < Formula
+  version '8.3.456'
   desc "VLSI layout tool written in Tcl"
   homepage "http://opencircuitdesign.com/magic/"
-  url "https://github.com/RTimothyEdwards/magic/archive/refs/tags/8.3.456.tar.gz"
+  url "https://github.com/RTimothyEdwards/magic/archive/refs/tags/#{version}.tar.gz"
   sha256 "ef17c343c89ac54699f87f6c853ec7e4814f322734bd3b54a157a7d95cab905a"
   license "MIT"
 
@@ -80,17 +81,6 @@ class MagicVlsi < Formula
   end
 
   test do
-    # `test do` will create, run in and delete a temporary directory.
-    #
-    # This test will fail and we won't accept that! For Homebrew/homebrew-core
-    # this will need to be a test that verifies the functionality of the
-    # software. Run the test with `brew test magic-vlsi`. Options passed
-    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
-    #
-    # The installed folder is not in the path, so use the entire path to any
-    # executables being tested: `system "#{bin}/program", "do", "something"`.
-
-    # TODO: write a real test
-    system "magic --version"
+    assert_match version, shell_output("#{bin}/magic --version", 0)
   end
 end

--- a/Formula/magic-vlsi.rb
+++ b/Formula/magic-vlsi.rb
@@ -32,14 +32,14 @@ class MagicVlsi < Formula
     resource("tcl").stage do
       tcl_tk_args = %W[
         --prefix=#{prefix}/tcl-tk
-        --includedir=#{include}/tcl-tk
         --mandir=#{man}
         --enable-threads
         --enable-64bit
       ]
 
       cd "unix" do
-        system "./configure", *tcl_tk_args
+        system "./configure",
+               *tcl_tk_args
         system "make"
         system "make", "install"
       end
@@ -52,13 +52,13 @@ class MagicVlsi < Formula
                  "--with-tcl=#{prefix}/tcl-tk/lib",
                  "--enable-xss=no",
                  "--with-x",
-                 "--x-includes=/usr/X11/include",
-                 "--x-libraries=/usr/X11/lib",
+                 "--x-includes=/opt/X11/include",
+                 "--x-libraries=/opt/X11/lib",
                  *tcl_tk_args
 
           inreplace "Makefile",
                     /^LIB_RUNTIME_DIR[^\n]*$/,
-                    "LIB_RUNTIME_DIR		= $(libdir)"
+                    "LIB_RUNTIME_DIR = $(libdir)"
 
           system "make"
           system "make", "install"
@@ -70,8 +70,8 @@ class MagicVlsi < Formula
            "--prefix=#{prefix}",
            "--with-tcl=#{prefix}/tcl-tk/lib",
            "--with-tk=#{prefix}/tcl-tk/lib",
-           "--x-includes=/usr/X11/include",
-           "--x-libraries=/usr/X11/lib",
+           "--x-includes=/opt/X11/include",
+           "--x-libraries=/opt/X11/lib",
            "--with-opengl=no", # disable OpenGL
            "--disable-silent-rules",
            "CFLAGS=-Wno-implicit-function-declaration",


### PR DESCRIPTION
As mentioned in https://github.com/RTimothyEdwards/magic/issues/280#issuecomment-1883451857, the `magic-vlsi` Formula isn't working for me... I'll continue to investigate.

I started _this_ pull request to take some of the content in https://github.com/Homebrew/homebrew-core/blob/master/Formula/t/tcl-tk.rb and move it to _here_. Primarily, I'm hoping to make this formula be compatible with a simultaneous installation of `core/tcl-tk`.