### PR TITLE
bump timeout to 30 minutes

### DIFF
--- a/.github/workflows/brew.yaml
+++ b/.github/workflows/brew.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     runs-on: [macos-13]
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - run: |


### PR DESCRIPTION
@shaunplee, the Formulas _should_ complete installation on the GitHub Action runner. These are clean slates so this should be our base-case.

(I'll keep trying different formulas and investigating the `tk` build failure on my local laptop as well...)